### PR TITLE
Formatting changes

### DIFF
--- a/wtsi-software-policy.tex
+++ b/wtsi-software-policy.tex
@@ -1,4 +1,5 @@
 \documentclass[10pt,a4paper]{article}
+\usepackage[a4paper,hmargin=1.25in,vmargin=1in]{geometry}
 \usepackage[utf8]{inputenc}
 \usepackage[colorlinks]{hyperref}
 \usepackage{verbatim}


### PR DESCRIPTION
Mostly formatting changes to reinstate blank lines separating paragraphs in appendix A boilerplates and to set narrower margins (which is, to be sure, a matter of taste; you may prefer not to merge ccd0d963e4990e453fed1719835f33017fa2bd8c).

Two suggested changes have some minor editorial content:
- Use ASCII double quotes instead of Unicode smart quotes in the copyright year range boilerplate
- Changed location of line breaks in the  list of conditions in the Modified-BSD boilerplate
